### PR TITLE
Increase SQA job timeout

### DIFF
--- a/osci.yaml
+++ b/osci.yaml
@@ -2,7 +2,7 @@
     name: sqa-integration
     max: 1
 - project:
-    periodic-weekly:
+    periodic-daily:
       jobs:
       - sit_sqa-integration_jammy-yoga
       - sit_sqa-integration_focal-yoga

--- a/osci.yaml
+++ b/osci.yaml
@@ -2,7 +2,7 @@
     name: sqa-integration
     max: 1
 - project:
-    periodic-daily:
+    periodic-weekly:
       jobs:
       - sit_sqa-integration_jammy-yoga
       - sit_sqa-integration_focal-yoga

--- a/osci.yaml
+++ b/osci.yaml
@@ -9,6 +9,7 @@
 - job:
     name: sit_sqa-integration
     parent: sqa-integration
+    timeout: 54600
     semaphore: sqa-integration
     abstract: true
     vars:


### PR DESCRIPTION
Increase the SQA integration jobs timeout to 15h and 10 min (10 min more than the [playbook itself](https://github.com/openstack-charmers/zosci-config/blob/master/playbooks/sqalab/run.yaml))